### PR TITLE
Allow Fluentd v1.19.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes_metadata_filter (3.7.1)
-      fluentd (>= 0.14.0, < 1.19)
+      fluentd (>= 0.14.0, < 1.20)
       kubeclient (>= 4.0.0, < 5.0.0)
       sin_lru_redux
 

--- a/fluent-plugin-kubernetes_metadata_filter.gemspec
+++ b/fluent-plugin-kubernetes_metadata_filter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'fluentd', ['>= 0.14.0', '< 1.19']
+  spec.add_dependency 'fluentd', ['>= 0.14.0', '< 1.20']
   spec.add_dependency 'kubeclient', ['>= 4.0.0', '< 5.0.0']
   spec.add_dependency 'sin_lru_redux'
 end


### PR DESCRIPTION
Even though blog announce is not published yet, Fluentd v1.19.0 was released.
https://rubygems.org/gems/fluentd/versions/1.19.0
